### PR TITLE
chore: postinstall -> prepare to avoid running script in end user side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "pi-messenger-swarm",
       "version": "0.17.10",
-      "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "pi-messenger-swarm": "install.mjs"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit",
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
-    "postinstall": "simple-git-hooks"
+    "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",


### PR DESCRIPTION
### Summary of changes
Postinstall -> prepare so the script only run on development, not user installation.

referrence: https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts

Currently when I install(or update via `pi update`), i encounter this issue
```
npm error code 127
npm error path /home/tropicaldog17/.nvm/versions/node/v24.11.1/lib/node_modules/pi-messenger-swarm
npm error command failed
npm error command sh -c simple-git-hooks
npm error sh: 1: simple-git-hooks: not found
```
I need to run `npm install -g pi-messenger-swarm@latest --ignore-scripts` to able to install the plugin
