### PR TITLE
fix: move simple-git-hooks from postinstall to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:dead": "knip --no-gitignore",
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
-    "postinstall": "simple-git-hooks"
+    "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1,0 +1,15 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('package manifest', () => {
+  it('does not run dev-only hooks during consumer install', () => {
+    const packageJsonPath = path.join(import.meta.dirname, '..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.postinstall).toBeUndefined();
+    expect(packageJson.scripts?.prepare).toBe('simple-git-hooks');
+  });
+});


### PR DESCRIPTION
## Summary
- move `simple-git-hooks` from `postinstall` to `prepare` so npm consumers do not execute a dev-only hook installer
- add a regression test that guards the published manifest against reintroducing `postinstall`

## Why
Installing `pi-messenger-swarm` from npm currently fails because the published package runs `postinstall: simple-git-hooks`, but `simple-git-hooks` is only a dev dependency and is not present for consumers.

## Verification
- `npm test`
- `npm run typecheck`
- `npm pack`
- `npm install --global --prefix "$(mktemp -d)" ./pi-messenger-swarm-0.18.2.tgz`
- `pi-messenger-swarm --help`